### PR TITLE
Refactor: Cleanup dependencies, imports, and ViewModel state updates

### DIFF
--- a/app-lite/build.gradle.kts
+++ b/app-lite/build.gradle.kts
@@ -1,7 +1,4 @@
 import com.autonomousapps.DependencyAnalysisSubExtension
-import kotlin.apply
-import org.gradle.kotlin.dsl.android
-import org.gradle.kotlin.dsl.findByType
 
 plugins {
     alias(libs.plugins.movies.dependency.analysis)

--- a/app-lite/dependencies/releaseRuntimeClasspath.txt
+++ b/app-lite/dependencies/releaseRuntimeClasspath.txt
@@ -161,7 +161,7 @@ org.jetbrains.compose.ui:ui-text:1.9.3
 org.jetbrains.compose.ui:ui-unit:1.9.3
 org.jetbrains.compose.ui:ui-util:1.9.3
 org.jetbrains.compose.ui:ui:1.9.3
-org.jetbrains.kotlin:kotlin-stdlib:2.3.20-RC3
+org.jetbrains.kotlin:kotlin-stdlib:2.3.20
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2
 org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.10.2
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.2

--- a/app-lite/proguard-rules.pro
+++ b/app-lite/proguard-rules.pro
@@ -34,3 +34,4 @@
 -dontwarn kotlinx.serialization.**
 -dontwarn androidx.emoji2.**
 -dontwarn androidx.window.extensions.**
+-dontwarn androidx.window.sidecar.**

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,4 @@
 import com.autonomousapps.DependencyAnalysisSubExtension
-import kotlin.apply
-import org.gradle.kotlin.dsl.findByType
 
 plugins {
 //    alias(libs.plugins.dexcount)

--- a/app/dependencies/releaseRuntimeClasspath.txt
+++ b/app/dependencies/releaseRuntimeClasspath.txt
@@ -221,7 +221,7 @@ org.jetbrains.compose.ui:ui-text:1.9.3
 org.jetbrains.compose.ui:ui-unit:1.9.3
 org.jetbrains.compose.ui:ui-util:1.9.3
 org.jetbrains.compose.ui:ui:1.9.3
-org.jetbrains.kotlin:kotlin-stdlib:2.3.20-RC3
+org.jetbrains.kotlin:kotlin-stdlib:2.3.20
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2
 org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.10.2
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.2

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.2.0-alpha02" type="baseline" client="gradle" dependencies="false" name="AGP (9.2.0-alpha02)" variant="all" version="9.2.0-alpha02">
+<issues format="6" by="lint 9.1.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.1.0)" variant="all" version="9.1.0">
 
     <issue
         id="MissingClass"
@@ -25,46 +25,13 @@
 
     <issue
         id="AndroidGradlePluginVersion"
-        message="A newer version of com.android.application than 9.2.0-alpha02 is available: 9.2.0-alpha04"
-        errorLine1="android-gradle-plugin = &quot;9.2.0-alpha02&quot;"
-        errorLine2="                        ~~~~~~~~~~~~~~~">
+        message="A newer version of Gradle than 9.4.0 is available: 9.4.1"
+        errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="$HOME/work/Movies/Movies/gradle/libs.versions.toml"
-            line="2"
-            column="25"/>
-    </issue>
-
-    <issue
-        id="AndroidGradlePluginVersion"
-        message="A newer version of com.android.library than 9.2.0-alpha02 is available: 9.2.0-alpha04"
-        errorLine1="android-gradle-plugin = &quot;9.2.0-alpha02&quot;"
-        errorLine2="                        ~~~~~~~~~~~~~~~">
-        <location
-            file="$HOME/work/Movies/Movies/gradle/libs.versions.toml"
-            line="2"
-            column="25"/>
-    </issue>
-
-    <issue
-        id="AndroidGradlePluginVersion"
-        message="A newer version of com.android.lint than 9.2.0-alpha02 is available: 9.2.0-alpha04"
-        errorLine1="android-gradle-plugin = &quot;9.2.0-alpha02&quot;"
-        errorLine2="                        ~~~~~~~~~~~~~~~">
-        <location
-            file="$HOME/work/Movies/Movies/gradle/libs.versions.toml"
-            line="2"
-            column="25"/>
-    </issue>
-
-    <issue
-        id="AndroidGradlePluginVersion"
-        message="A newer version of com.android.tools.build:gradle than 9.2.0-alpha02 is available: 9.2.0-alpha04"
-        errorLine1="android-gradle-plugin = &quot;9.2.0-alpha02&quot;"
-        errorLine2="                        ~~~~~~~~~~~~~~~">
-        <location
-            file="$HOME/work/Movies/Movies/gradle/libs.versions.toml"
-            line="2"
-            column="25"/>
+            file="$HOME/StudioProjects/Movies/gradle/wrapper/gradle-wrapper.properties"
+            line="3"
+            column="17"/>
     </issue>
 
 </issues>

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -29,7 +29,7 @@
         errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip"
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="$HOME/StudioProjects/Movies/gradle/wrapper/gradle-wrapper.properties"
+            file="$HOME/work/Movies/Movies/gradle/wrapper/gradle-wrapper.properties"
             line="3"
             column="17"/>
     </issue>

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -4,7 +4,6 @@ import com.bz.movies.configureKotlinAndroid
 import com.bz.movies.disableUnnecessaryAndroidTests
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 
 class AndroidLibraryConventionPlugin : Plugin<Project> {

--- a/build-logic/convention/src/main/kotlin/AndroidTestConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidTestConventionPlugin.kt
@@ -1,5 +1,4 @@
 import com.android.build.api.dsl.TestExtension
-import com.bz.movies.configureKotlinAndroid
 import com.bz.movies.configureKotlinTestAndroid
 import org.gradle.api.Plugin
 import org.gradle.api.Project

--- a/build-logic/convention/src/main/kotlin/HiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/HiltConventionPlugin.kt
@@ -1,4 +1,3 @@
-import com.android.build.gradle.api.AndroidBasePlugin
 import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project

--- a/build-logic/convention/src/main/kotlin/com/bz/movies/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/bz/movies/KotlinAndroid.kt
@@ -4,7 +4,6 @@ import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.dsl.TestExtension
-import kotlin.collections.plusAssign
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
@@ -16,7 +15,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
-import org.jetbrains.kotlin.gradle.dsl.abi.AbiValidationExtension
 import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 fun ApplicationExtension.baseAppConfig() {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,11 +2,6 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
-import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
-import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jlleitschuh.gradle.ktlint.KtlintPlugin
 // import org.gradle.android.AndroidCacheFixPlugin
 // import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android-gradle-plugin = "9.2.0-alpha02"
+android-gradle-plugin = "9.1.0"
 android-tools = "32.1.0"
 androidx-activity = "1.13.0"
 androidx-appcompat = "1.7.1"
@@ -31,7 +31,7 @@ hilt = "2.59.2"
 javax-inject = "1"
 junit = "6.0.3"
 kermit = "2.1.0"
-kotlin = "2.3.20-RC3"
+kotlin = "2.3.20"
 kotlinx-coroutines = "1.10.2"
 kotlinx-kover = "0.9.7"
 ksp = "2.3.6"
@@ -170,6 +170,7 @@ gradle-versions = { id = "com.github.ben-manes.versions", version = "0.53.0" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 #kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-plugin = { id = "kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kotlinx-kover" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-plugin" }

--- a/presentation/screens/src/main/kotlin/com/bz/movies/presentation/screens/more/MoreScreenViewModel.kt
+++ b/presentation/screens/src/main/kotlin/com/bz/movies/presentation/screens/more/MoreScreenViewModel.kt
@@ -11,6 +11,7 @@ import com.bz.movies.presentation.utils.LocaleSelector
 import com.bz.network.repository.CurrencyRepository
 import dagger.Lazy
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,7 +21,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @HiltViewModel
 internal class MoreScreenViewModel @Inject constructor(

--- a/presentation/screens/src/main/kotlin/com/bz/movies/presentation/screens/more/MoreScreenViewModel.kt
+++ b/presentation/screens/src/main/kotlin/com/bz/movies/presentation/screens/more/MoreScreenViewModel.kt
@@ -11,7 +11,6 @@ import com.bz.movies.presentation.utils.LocaleSelector
 import com.bz.network.repository.CurrencyRepository
 import dagger.Lazy
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,7 +18,9 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
 internal class MoreScreenViewModel @Inject constructor(
@@ -72,8 +73,10 @@ internal class MoreScreenViewModel @Inject constructor(
                     )
                 }
                 .onFailure {
-                    _state.value.copy(exchangeRate = null)
                     Logger.e("Loading exchange error", it)
+                    _state.update {
+                        _state.value.copy(exchangeRate = null)
+                    }
                 }
         }
     }

--- a/presentation/screens/src/main/kotlin/com/bz/movies/presentation/screens/popular/PopularMoviesViewModel.kt
+++ b/presentation/screens/src/main/kotlin/com/bz/movies/presentation/screens/popular/PopularMoviesViewModel.kt
@@ -99,8 +99,8 @@ internal class PopularMoviesViewModel @Inject constructor(
                 }
             _effect.send(error)
             Logger.e("Loading error", it)
-            _state.update {
-                it.copy(
+            _state.update { moviesState ->
+                moviesState.copy(
                     isLoading = false,
                     isRefreshing = false
                 )

--- a/presentation/screens/src/main/kotlin/com/bz/movies/presentation/theme/Theme.kt
+++ b/presentation/screens/src/main/kotlin/com/bz/movies/presentation/theme/Theme.kt
@@ -15,19 +15,17 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
-private val DarkColorScheme =
-    darkColorScheme(
-        primary = Purple80,
-        secondary = PurpleGrey80,
-        tertiary = Pink80
-    )
+private val DarkColorScheme = darkColorScheme(
+    primary = Purple80,
+    secondary = PurpleGrey80,
+    tertiary = Pink80
+)
 
-private val LightColorScheme =
-    lightColorScheme(
-        primary = Purple40,
-        secondary = PurpleGrey40,
-        tertiary = Pink40
-    )
+private val LightColorScheme = lightColorScheme(
+    primary = Purple40,
+    secondary = PurpleGrey40,
+    tertiary = Pink40
+)
 
 @Composable
 internal fun MoviesTheme(

--- a/presentation/screens/src/test/java/com/bz/movies/presentation/screens/details/MovieDetailsViewModelTest.kt
+++ b/presentation/screens/src/test/java/com/bz/movies/presentation/screens/details/MovieDetailsViewModelTest.kt
@@ -13,6 +13,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import kotlin.random.Random
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
@@ -25,7 +26,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import kotlin.random.Random
 
 class MovieDetailsViewModelTest {
 

--- a/presentation/screens/src/test/java/com/bz/movies/presentation/screens/details/MovieDetailsViewModelTest.kt
+++ b/presentation/screens/src/test/java/com/bz/movies/presentation/screens/details/MovieDetailsViewModelTest.kt
@@ -7,14 +7,12 @@ import com.bz.movies.presentation.screens.common.MovieEffect
 import com.bz.movies.presentation.screens.common.MovieItem
 import com.bz.network.repository.HttpException
 import com.bz.network.repository.MovieRepository
-import dagger.Lazy
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
-import kotlin.random.Random
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
@@ -27,6 +25,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class MovieDetailsViewModelTest {
 
@@ -38,7 +37,7 @@ class MovieDetailsViewModelTest {
             SUCCESS_MOVIE_DETAIL
         )
 
-        val viewModel = MovieDetailsViewModel(Lazy { movieRepository })
+        val viewModel = MovieDetailsViewModel { movieRepository }
         viewModel.state.test {
             val actualItem = awaitItem()
             val expectedItem = MovieDetailState()
@@ -59,7 +58,7 @@ class MovieDetailsViewModelTest {
         mockkObject(Random)
         every { Random.nextInt(any(), any()) } returns 69
 
-        val viewModel = MovieDetailsViewModel(Lazy { movieRepository })
+        val viewModel = MovieDetailsViewModel { movieRepository }
         viewModel.state.test {
             assertEquals(MovieDetailState(), awaitItem())
             expectNoEvents()
@@ -82,7 +81,7 @@ class MovieDetailsViewModelTest {
                 )
             } returns Result.failure(HttpException(""))
 
-            val viewModel = MovieDetailsViewModel(Lazy { movieRepository })
+            val viewModel = MovieDetailsViewModel { movieRepository }
             viewModel.fetchMovieDetails(1234)
             viewModel.effect.test {
                 assertEquals(MovieEffect.NetworkConnectionError, awaitItem())
@@ -98,7 +97,7 @@ class MovieDetailsViewModelTest {
             movieRepository.getMovieDetail(any())
         } returns Result.failure(IllegalStateException())
 
-        val viewModel = MovieDetailsViewModel(Lazy { movieRepository })
+        val viewModel = MovieDetailsViewModel { movieRepository }
         viewModel.fetchMovieDetails(1234)
         viewModel.effect.test {
             assertEquals(MovieEffect.UnknownError, awaitItem())

--- a/presentation/screens/src/test/java/com/bz/movies/presentation/screens/favorite/FavoriteScreenViewModelTest.kt
+++ b/presentation/screens/src/test/java/com/bz/movies/presentation/screens/favorite/FavoriteScreenViewModelTest.kt
@@ -3,7 +3,6 @@ package com.bz.movies.presentation.screens.favorite
 import app.cash.turbine.test
 import com.bz.movies.database.repository.LocalMovieRepository
 import com.bz.movies.presentation.screens.common.MoviesState
-import dagger.Lazy
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -28,7 +27,7 @@ class FavoriteScreenViewModelTest {
             every { localMovieRepository.favoritesMovies } returns flowOf(emptyList())
 
             val viewModel = FavoriteScreenViewModel(
-                localMovieRepository = Lazy { localMovieRepository }
+                localMovieRepository = { localMovieRepository }
             )
             viewModel.state.test {
                 val actualItem = awaitItem()


### PR DESCRIPTION
This commit performs a general cleanup across the project, including dependency version adjustments, removal of unused imports, and refactoring of ViewModel state logic and unit tests.

Additionally, this change includes:

- Downgrades `android-gradle-plugin` to `9.1.0` and `kotlin` to `2.3.20`.
- Refactors `MovieDetailsViewModelTest` and `FavoriteScreenViewModelTest` to use function providers (lambdas) instead of `dagger.Lazy` for simplified testing.
- Updates `MoreScreenViewModel` to use `MutableStateFlow.update` to ensure thread-safe state updates during error handling.
- Adds a ProGuard rule to suppress warnings for `androidx.window.sidecar.**` in the lite app module.
- Removes unused imports across multiple build scripts and source files.
- Improves code readability by naming lambda parameters in `PopularMoviesViewModel` and formatting `Theme.kt`.